### PR TITLE
Edit SAP exceptions

### DIFF
--- a/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
+++ b/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
@@ -15,23 +15,28 @@ downloads:
   - name: SAPExeptionHandling.pbmx
     url: /assets/2024-04-16/SAPExeptionHandling.pbmx
 ---
-All readers of this blog know, that there are [a lot of SAP articles](https://how-to-dismantle-a-peakboard-box.com/category/sap) available. The last one was [SAP on fire - how to perfectly integrate LUA scripting with SAP](/SAP-on-fire-how-to-perfectly-integrate-LUA-scripting-with-SAP.html). But in this article there was one last aspect missing, which we will discuss here.
+As readers of this blog know, we have [a lot of articles about SAP](https://how-to-dismantle-a-peakboard-box.com/category/sap). The last one was [SAP on fire - how to perfectly integrate LUA scripting with SAP](/SAP-on-fire-how-to-perfectly-integrate-LUA-scripting-with-SAP.html). But there was something missing in that article, which we will discuss now.
 
-In this article, we will learn how to handle ABAP exceptions when calling RFC function modules or BAPIs in SAP from Peakboard.
+In this article, we will learn how to handle ABAP exceptions when calling RFC function modules or BAPIs, in SAP, from Peakboard.
  
 ## RFC exceptions
 
-SAP ABAP has a very unique (some might say old-fashioned) way of handling exceptions in function modules. If we look at transaction SE37 to find out more, we can find the Exceptions tab. The screenshot shows a very simple, standard RFC function module called SD_RFC_CUSTOMER_GET. It returns a list of customers according to the search pattern for customer name and customer number (NAME1 and KUNNR). As we see in the screenshot the function module throws (yes, we use the term 'to throw') two exceptions. NOTHING_SPECIFIED is thrown, when the caller fails to submit any useful import parameters. NO_RECORD_FOUND is thrown when the serach pattern doesn't lead to any data rows in the result set.
+SAP ABAP has a very unique (some might say old-fashioned) way of handling exceptions in function modules. If we look at transaction `SE37` to find out more, we see the **Exceptions** tab.
+
+The following screenshot shows a simple, standard RFC function module called `SD_RFC_CUSTOMER_GET`. It returns a list of customers, according to the search pattern for the customer name and customer number (`NAME1` and `KUNNR`). As you can see in the screenshot, the function module throws two exceptions (yes, we use the term *throws*). 
+
+* `NOTHING_SPECIFIED` is thrown when the caller fails to submit any useful import parameters.
+* `NO_RECORD_FOUND` is thrown when the search pattern doesn't lead to any data rows in the result set.
 
 ![image](/assets/2024-04-16/010.png)
 
 ## Handling exceptions in LUA
 
-Calling the SD_RFC_CUSTOMER_GET function is straight forward. In our Peaboard app we just use a very simple canvas to ask the user for his input. The actual SAP call is then happening behind the button in LUA.
+Calling the `SD_RFC_CUSTOMER_GET` function is straightforward. Our Peakboard app has a simple canvas that asks the user for their input. The actual SAP call happens once the button is pressed. We use LUA to make the call.
 
 ![image](/assets/2024-04-16/020.png)
 
-The basic LUA to do this, we can see here. We see, that the actual XQL has a dynamic component that is filled through a placeholder. The execution of the XQL just returns one table that can be easily processed.
+The following is the basic LUA for the call. As you can see, the XQL has a dynamic component that is filled with a placeholder. The XQL returns one table, which can be easily processed.
 
 {% highlight lua %}
 local con = connections.getfromid('As4kF5peAjw+3MIuEQf3Fc1kEeY=')
@@ -51,7 +56,7 @@ local returntable = con.execute(xql)
 peakboard.log(returntable.count .. ' rows found')
 {% endhighlight %}
 
-The secret trick to understand is that the 'execute' function not only returns the output of the XQL statement, but also a second object that represents all potential errors. To process both objects we need to adjust the call to handle both objects. 
+The trick is to understand that the `execute` function not only returns the output of the XQL statement, but also a second object that represents all potential errors. So, we need to adjust the call to handle both objects. 
 
 {% highlight lua %}
 local returntable, error = con.execute(xql)  
@@ -72,10 +77,13 @@ elseif returntable then
 end
 {% endhighlight %}
 
-The error object offers two more attribute worth to mention: 'message' is just a generic message that comes from the XQL engine. It might helpful to dump this message into the log for further investigation. The attribute 'stacktrace' goes deep into the technical details that lead to the error. It might used for support cases or other low lever debugging.
+The error object offers two more attributes worth mentioning:
 
-## conlusion
+* `message` is a generic message that comes from the XQL engine. It might be helpful to dump this message into the log for further investigation.
+* `stacktrace` goes deep into the technical details that lead to the error. It might be useful for support cases or other low level debugging.
 
-Every time we use XQL in a real life project it's a good habit to process and check for the error objects as shown in this article. Even though an RFC function module is not supposed to throw any ABAP exceptions they can occur because of unforeseeable circumstances.
+## Conclusion
+
+Every time we use XQL in a real-world project, it's a good habit to process and check for the error objects, as shown in this article. Even though an RFC function module is not supposed to throw any ABAP exceptions, they can occur because of unforeseeable circumstances.
 
 

--- a/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
+++ b/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
@@ -74,7 +74,7 @@ In the case of an error, the `type` attribute is the first thing to check. There
 * If `type` is `ABAP`, that means the exception was thrown by the SAP system.
 * If `type` is `XQL`, that means there was a syntax error in the XQL.
 
-So we have to check for ABAP-errors first. Then, we can use the `code` attribute to get the actual exception string, which we saw in `SE37` earlier. This makes it possible to react based on which exception is thrown.
+So we have to check for ABAP errors first. Then, we can use the `code` attribute to get the actual exception string, which we saw in `SE37` earlier. This makes it possible to react based on which exception is thrown.
 
 {% highlight lua %}
 if error then

--- a/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
+++ b/_posts/2024-04-16-Expect-the-unexpected-How-to-handle-SAP-exceptions-in-LUA-scripting.md
@@ -62,8 +62,19 @@ The trick is to understand that the `execute` function not only returns the outp
 local returntable, error = con.execute(xql)  
 {% endhighlight %}
 
-If there is an error, the resulttable is 'nil' and error object is filled. In case of an error, the error object is filled, but resulttable is 'nil'.
-This makes it possible to distiniguish between these cases. When it comes to an error the attribute 'type' is the first thing to check. There are two options: Type 'ABAP' is an exception that is thrown by the SAP system, in case of 'XQL' there might be syntax error in the XQL. So we have to check for ABAP-errors first, and then can use the 'code' attribute to get the actual exception string that we already saw in SE37 earlier. This makes it possible to react accordingly to which exception is thrown.
+There are two possible cases:
+
+* If there is an error, the result table is `nil` and the error object is filled.
+* If there is no error, the result table is filled and the the error object is `nil`.
+
+This makes it possible to distinguish between the error and no-error cases.
+
+In the case of an error, the `type` attribute is the first thing to check. There are two options:
+
+* If `type` is `ABAP`, that means the exception was thrown by the SAP system.
+* If `type` is `XQL`, that means there was a syntax error in the XQL.
+
+So we have to check for ABAP-errors first. Then, we can use the `code` attribute to get the actual exception string, which we saw in `SE37` earlier. This makes it possible to react based on which exception is thrown.
 
 {% highlight lua %}
 if error then


### PR DESCRIPTION
Everything is edited, except for one paragraph, which I have some questions about:

>If there is an error, the resulttable is 'nil' and error object is filled. In case of an error, the error object is filled, but resulttable is 'nil'.

I think the second sentence is supposed to be something else? Since it's just repeating the first sentence, but in a different order.

>This makes it possible to distiniguish between these cases.

Just to clarify, this is saying that it IS POSSIBLE to distinguish, right?