### PR TITLE
Fix typos in May the Popup Be With You article

### DIFF
--- a/_posts/2025-10-10-May-the-Popup-Be-With-You-Remote-Alerts-on-Peakboard.md
+++ b/_posts/2025-10-10-May-the-Popup-Be-With-You-Remote-Alerts-on-Peakboard.md
@@ -13,26 +13,25 @@ downloads:
   - name: PopupMessage.pbmx
     url: /assets/2025-10-10/PopupMessage.pbmx
 ---
-Earlier this year we discussed how to use the [Peakboard Hub API to send a notification from any kind of client to a Peakboard box through the Hub](/Cracking-the-code-Part-II-Calling-functions-remotely.html). That's especially cool when the Peakboard box (or BYOD instance) is not directly reachable from the caller or the ip adress is unknown. It works even with remote boxes as long as they are connected to Peakboard Hub Online. But let's assume now, we are only operating within one local facility and the box can be access directly without any restriction. In that case, no hub in between is necessary, we can just send our notifcation directly from the caller to box without any relay. How to do that we will discuss in today's article.
+Earlier this year we discussed how to use the [Peakboard Hub API to send a notification from any kind of client to a Peakboard box through the Hub](/Cracking-the-code-Part-II-Calling-functions-remotely.html). That's especially cool when the Peakboard box (or BYOD instance) is not directly reachable from the caller or the IP address is unknown. It works even with remote boxes as long as they are connected to Peakboard Hub Online. But let's assume now, we are only operating within one local facility and the box can be accessed directly without any restriction. In that case, no hub in between is necessary—we can just send our notification directly from the caller to the box without any relay. How to do that we will discuss in today's article.
 
 ## The Peakboard application
 
-for our exmaple we need a simple Peakboard application. It only contains a big text box for the message and a button to let the user confirm the notification. Both elements are hidden by default. So confirming a message is nothing else then setting the text box and the button back to hidden.
+For our example we need a simple Peakboard application. It contains a big text box for the message and a button to let the user confirm the notification. Both elements are hidden by default, so confirming a message is nothing else than setting the text box and the button back to hidden.
 
 ![image](/assets/2025-10-10/010.png)
 
-Beside the two controls we will need a function called `SubmitNotification` which receives a parameter `Message` that contains the actual payload to be presented to the user. The function must be marked as `shared` to allow it to be called from the outside.
+Besides the two controls we will need a function called `SubmitNotification` which receives a parameter `Message` that contains the actual payload to be presented to the user. The function must be marked as `shared` to allow it to be called from the outside.
 
 ![image](/assets/2025-10-10/020.png)
 
-That's all we need. Now the application can be deplyoed on a box or on a BYOD instance waiting for incoming messages. The next screenshot shows an incoming message in the running application and how to confirm it.
+That's all we need. Now the application can be deployed on a box or on a BYOD instance waiting for incoming messages. The next screenshot shows an incoming message in the running application and how to confirm it.
 
 ![image](/assets/2025-10-10/result.gif)
 
 ## Calling from C#
 
-As we created a shared function the function automatically exposes an endpoint into the network. The following code show to call that function. It's a regular HTTP post call. The pattern for the URL is `http://<BoxNameOrIP>:40404/api/functions/<FunctionName>`. In the body we need to provide the `Message` value as payload.
-The endpoint is protected by box credentials. Ideally we create an account on the box that can only call functions and nothing else. In case the credentiels get lost they can't be used to access the box as administrators.
+As we created a shared function, it automatically exposes an endpoint into the network. The following code shows how to call that function. It's a regular HTTP POST call. The pattern for the URL is `http://<BoxNameOrIP>:40404/api/functions/<FunctionName>`. In the body we need to provide the `Message` value as payload. The endpoint is protected by box credentials. Ideally we create an account on the box that can only call functions and nothing else. In case the credentials get lost they can't be used to access the box as administrators.
 
 {% highlight csharp %}
 var url = "http://comicbookguy:40404/api/functions/SubmitNotification";
@@ -56,7 +55,7 @@ using (var client = new HttpClient())
 
 ## Calling from Python
 
-In case we want to do the same using Python here's a typical sample for Pything Users.
+In case we want to do the same using Python here's a typical sample for Python users.
 
 {% highlight python %}
 import requests
@@ -64,7 +63,7 @@ from requests.auth import HTTPBasicAuth
 
 def main():
     url = "http://comicbookguy:40404/api/functions/SubmitNotification"
-    payload = {"Message": "The roof is fire!"}
+    payload = {"Message": "The roof is on fire!"}
     username = "ExternalCaller"
     password = "xxx"
 
@@ -82,7 +81,7 @@ if __name__ == "__main__":
 
 ## Set up a box user
 
-It's very important to keep safety in mind and not use an Administrator account to call the function. Ideally we create a `Caller` role on the user and create a new user bound to this role as shown in the screenshot. They we can make sure that the caller only can call and nothing else. Calling a function is considered as "Write Data".
+It's very important to keep safety in mind and not use an Administrator account to call the function. Ideally we create a `Caller` role on the user and create a new user bound to this role as shown in the screenshot. Then we can make sure that the caller can only call and nothing else. Calling a function is considered as "Write Data".
 
 ![image](/assets/2025-10-10/030.png)
 


### PR DESCRIPTION
## Summary
- Fix spelling and grammar in "May the Popup Be With You" blog post
- Clarify Python example and user-role security guidance

## Testing
- `NODE_ENV=production npx tailwindcss -i ./src/css/main.css -o ./assets/css/main.css`
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b91ffe1b10832bb98541a8bf4d7242